### PR TITLE
Blocking Publish API

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,9 @@ last_id = 1 // initial value
 next_id = last_id + 1
 last_id = next_id
 ```
-- If you're a publisher, you should concern yourself with only `PubSub.Publish(...)` method.
+- If you're a publisher, you should concern yourself with either of
+    - `PubSub.Publish(...)` [ **non-blocking** ]
+    - or `PubSub.BPublish(...)` [ **blocking** ]
 - If you're a subscriber, you should first subscribe to `N`-many topics, using `PubSub.Subscribe(...)`. You can start reading using
     - `Subscriber.Next()` [ **non-blocking** ]
     - `Subscriber.BNext(...)` [ **blocking** ]

--- a/extras.go
+++ b/extras.go
@@ -1,5 +1,7 @@
 package pubsub
 
+import "time"
+
 // Message - Publisher showing intent of publishing arbitrary byte slice to topics
 type Message struct {
 	Topics []string
@@ -10,6 +12,7 @@ type Message struct {
 // while receiving how many subscribers it published to
 type PublishRequest struct {
 	Message      *Message
+	BlockFor     time.Duration
 	ResponseChan chan uint64
 }
 

--- a/pubsub_test.go
+++ b/pubsub_test.go
@@ -143,7 +143,7 @@ func TestPubSub(t *testing.T) {
 
 	}
 
-	published, count = pubsub.Publish(&msg)
+	published, count = pubsub.BPublish(&msg, time.Duration(1)*time.Millisecond)
 	if !published {
 		t.Errorf("Expected to be able to publish to topic")
 	}


### PR DESCRIPTION
## What's new ?

Added new API for publishing in blocking mode i.e. if found subscriber channel doesn't have space to hold message `M`, hub will wait for duration `D` ( specified by publisher ) & reattempt publishing. If failed this time too, simply returns back without blocking.
