### PR TITLE
Improved Consumer Inbox Memory Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ touch main.go
 Now add `github.com/itzmeanjan/pubsub` as your project dependency
 
 ```bash
-go get github.com/itzmeanjan/pubsub # v0.1.6 latest
+go get github.com/itzmeanjan/pubsub # v0.1.7 latest
 ```
 
 And follow full [example](./example/main.go).

--- a/pubsub_test.go
+++ b/pubsub_test.go
@@ -23,11 +23,11 @@ func TestPubSub(t *testing.T) {
 		t.Errorf("Expected subscriber count to be 0, got %d", count)
 	}
 
-	if subscriber := pubsub.Subscribe(16); subscriber != nil {
+	if subscriber := pubsub.Subscribe(2); subscriber != nil {
 		t.Errorf("Expected no creation of subscriber")
 	}
 
-	subscriber := pubsub.Subscribe(16, TOPIC_1)
+	subscriber := pubsub.Subscribe(2, TOPIC_1)
 	if subscriber == nil && subscriber.id != 1 {
 		t.Errorf("Expected creation of subscriber")
 	}


### PR DESCRIPTION
## What's new ?

Each consumer has one message inbox which works as buffer & when consumer is ready, it'll pull oldest message from inbox & act on it.

Previously when buffer capacity was reached ( mostly consumer is slow ), new buffer was allocated with double capacity & old contents were copied to new. But after sometime consumer is now faster, so inbox is not anymore full, rather just memory is allocated in hope it may reach capacity in sometime future. It was resulting into poor memory management & when application was running for long time, slices were not eligible for **GC**. 

Rather now, when message inbox capacity needs to be incremented, it's just done by `+ 1`, results in lesser memory consumption ( or _waste !_ ).
